### PR TITLE
Exclude subdirs from install

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,4 @@
 AUTOMAKE_OPTIONS = foreign
 ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = external/idevicerestore external/tsschecker futurerestore
+install installdirs: SUBDIRS = futurerestore


### PR DESCRIPTION
(this is cherry-picked from https://github.com/encounter/futurerestore/commit/2568c6bf01a99b2991cf847fb3d0fbaa662b0320 in @encounter's fork)

Currently when running `make install`, the following files are installed which aren't needed for futurerestore and cause conflicts for package managers:
* `/usr/lib/libjssy.a`
* `/usr/share/man/man1/idevicerestore.1.gz`

To fix this, restrict install to only futurerestore files.